### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through a stack trace

### DIFF
--- a/src/middlewares/error.ts
+++ b/src/middlewares/error.ts
@@ -43,7 +43,8 @@ export default function error() {
       } else {
         // others
         ctx.status = 500;
-        ctx.body = errHtml.replace('<%= errMsg %>', errMsg).replace('<%= errStack %>', stack || '');
+        Printer.error('MDW-err stack trace:', stack || 'No stack trace available');
+        ctx.body = errHtml.replace('<%= errMsg %>', errMsg).replace('<%= errStack %>', 'An internal server error occurred.');
       }
     }
     // ================================================


### PR DESCRIPTION
Potential fix for [https://github.com/Froguard/mihawk/security/code-scanning/2](https://github.com/Froguard/mihawk/security/code-scanning/2)

To fix the issue, the stack trace should not be included in the response body sent to the client. Instead, the stack trace should be logged on the server for debugging purposes, and a generic error message should be sent to the client. This ensures that sensitive information is not exposed while still allowing developers to diagnose issues using server logs.

The fix involves:
1. Removing the inclusion of `stack` in the response body on line 46.
2. Logging the stack trace on the server using the `Printer.error` method or another logging mechanism.
3. Sending a generic error message to the client in place of the stack trace.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
