### PR TITLE
Potential fix for code scanning alert no. 7: Server-side request forgery

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -8,6 +8,22 @@
  * @description
  */
 export async function jsonRequest<R = Record<string, any>>(url: string, options?: Record<string, any>) {
+  // basic SSRF mitigation: only allow http/https URLs and block obvious loopback hosts
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+  const protocol = parsedUrl.protocol;
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    throw new Error(`Unsupported URL protocol: ${protocol}`);
+  }
+  const hostname = parsedUrl.hostname.toLowerCase();
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
+    throw new Error(`Blocked URL host: ${hostname}`);
+  }
+
   // format options
   const isHttps = url.startsWith('https://');
   options = formatOptions(options, isHttps);


### PR DESCRIPTION
Potential fix for [https://github.com/Froguard/mihawk/security/code-scanning/7](https://github.com/Froguard/mihawk/security/code-scanning/7)

In general, to fix SSRF here we should restrict what URLs `jsonRequest` will call, since it is the central HTTP client. We should ensure only HTTP(S) URLs are allowed, optionally enforce that the host is in an allow‑list or at least not a loopback/localhost/private IP, and disallow attacker‑controlled full URLs from bypassing those checks. Because we must not change existing functionality more than necessary and we only see a small part of the codebase, a minimal, robust fix is to add URL validation inside `jsonRequest`, rejecting any URL that is not HTTP(S) or that points to `localhost`/loopback. This reduces the SSRF surface without needing to refactor `resolve-data.ts`.

Concretely in `src/utils/request.ts`, in `jsonRequest` we will parse the incoming `url` string with the standard `URL` constructor, verify its protocol is `http:` or `https:`, and reject otherwise. Additionally, we can block obviously dangerous hosts such as `localhost`, `127.0.0.1`, and `::1`. If resolution of internal IP ranges is needed, that would require more context and possibly additional dependencies; to avoid assumptions, we will implement only these simple, effective checks using built‑in APIs. If the URL fails validation, `jsonRequest` will throw an error before calling `fetch`. To keep changes minimal, we will not alter the call sites; we just insert validation logic at the start of `jsonRequest`. No new imports are required for the `URL` class in modern Node/TypeScript.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
